### PR TITLE
Agentfile: support more Dockerfile keywords

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-IMAGE_NAME ?= yeahdongcn/agentman:base
+IMAGE_NAME ?= yeahdongcn/agentman-base:latest
 
-default: run
+default: install
 
 .PHONY: publish-base-image
 publish-base-image:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Create a simple URL-to-social-media agent in 3 steps:
 1. **Create an Agentfile:**
 ```dockerfile
 # Agentfile
-FROM yeahdongcn/agentman:base
+FROM yeahdongcn/agentman-base:latest
 MODEL generic.qwen3:latest
 
 SECRET GENERIC
@@ -127,10 +127,10 @@ agentman run --rm my-agent:latest
 ### Base Configuration
 
 ```dockerfile
-FROM yeahdongcn/agentman:base     # Base image
-MODEL anthropic/claude-3-sonnet   # Default model for agents
-EXPOSE 8080                       # Expose ports
-CMD ["python", "agent.py"]        # Container startup command
+FROM yeahdongcn/agentman-base:latest   # Base image
+MODEL anthropic/claude-3-sonnet        # Default model for agents
+EXPOSE 8080                            # Expose ports
+CMD ["python", "agent.py"]             # Container startup command
 ```
 
 ### MCP Servers
@@ -200,7 +200,7 @@ TIMEOUT 30
 
 ### 1. Content Processing Pipeline
 ```dockerfile
-FROM yeahdongcn/agentman:base
+FROM yeahdongcn/agentman-base:latest
 MODEL anthropic/claude-3-sonnet
 
 MCP_SERVER brave
@@ -223,7 +223,7 @@ SEQUENCE researcher writer editor
 
 ### 2. Customer Support System
 ```dockerfile
-FROM yeahdongcn/agentman:base
+FROM yeahdongcn/agentman-base:latest
 MODEL anthropic/claude-3-haiku
 
 MCP_SERVER database
@@ -249,7 +249,7 @@ INSTRUCTION Route based on inquiry complexity and urgency
 
 ### 3. Data Analysis Workflow
 ```dockerfile
-FROM yeahdongcn/agentman:base
+FROM yeahdongcn/agentman-base:latest
 MODEL anthropic/claude-3-sonnet
 
 MCP_SERVER filesystem

--- a/examples/chain-aliyun/Agentfile
+++ b/examples/chain-aliyun/Agentfile
@@ -1,5 +1,5 @@
 # Chain Example Agentfile
-FROM yeahdongcn/agentman:base
+FROM yeahdongcn/agentman-base:latest
 MODEL qwen-plus
 
 SECRET ALIYUN_API_KEY sk-100

--- a/examples/chain-ollama/Agentfile
+++ b/examples/chain-ollama/Agentfile
@@ -1,5 +1,5 @@
 # Chain Example Agentfile
-FROM yeahdongcn/agentman:base
+FROM yeahdongcn/agentman-base:latest
 MODEL generic.qwen3:latest
 
 SECRET GENERIC

--- a/src/agentman/cli.py
+++ b/src/agentman/cli.py
@@ -52,7 +52,7 @@ class ArgumentParserWithDefaults(argparse.ArgumentParser):
 
 def get_description():
     return """\
-Manage agents
+A tool for building and managing AI agents
 """
 
 

--- a/tests/test_agent_builder.py
+++ b/tests/test_agent_builder.py
@@ -36,7 +36,7 @@ class TestAgentBuilder:
     def setup_method(self):
         """Set up test fixtures."""
         self.config = AgentfileConfig()
-        self.config.base_image = "yeahdongcn/agentman:base"
+        self.config.base_image = "yeahdongcn/agentman-base:latest"
         self.config.default_model = "generic.qwen3:latest"
         self.config.cmd = ["python", "agent.py"]
 
@@ -311,7 +311,7 @@ class TestAgentBuilder:
             with open(dockerfile, 'r') as f:
                 content = f.read()
 
-            assert "FROM yeahdongcn/agentman:base" in content
+            assert "FROM yeahdongcn/agentman-base:latest" in content
             assert "WORKDIR /app" in content
             assert 'CMD ["python", "agent.py"]' in content
 
@@ -331,8 +331,8 @@ class TestAgentBuilder:
             assert "EXPOSE 8080" in content
 
     def test_generate_dockerfile_fast_agent_base(self):
-        """Test Dockerfile generation with fast-agent:latest base."""
-        self.config.base_image = "fast-agent:latest"
+        """Test Dockerfile generation with yeahdongcn/agentman-base:latest base."""
+        self.config.base_image = "yeahdongcn/agentman-base:latest"
 
         with tempfile.TemporaryDirectory() as temp_dir:
             builder = AgentBuilder(self.config, temp_dir)
@@ -342,9 +342,9 @@ class TestAgentBuilder:
             with open(dockerfile, 'r') as f:
                 content = f.read()
 
-            assert "FROM python:3.11-slim" in content
-            assert "apt-get update" in content
-            assert "nodejs" in content
+            assert "FROM yeahdongcn/agentman-base:latest" in content
+            assert "COPY agent.py" in content
+            assert "RUN pip install" in content
 
     def test_generate_requirements_txt_basic(self):
         """Test basic requirements.txt generation."""

--- a/tests/test_agentfile_parser.py
+++ b/tests/test_agentfile_parser.py
@@ -39,7 +39,7 @@ class TestAgentfileParser:
         """Test parser initialization."""
         assert self.parser.config is not None
         assert isinstance(self.parser.config, AgentfileConfig)
-        assert self.parser.config.base_image == "fast-agent:latest"
+        assert self.parser.config.base_image == "yeahdongcn/agentman-base:latest"
         assert self.parser.config.secrets == []
         assert self.parser.config.servers == {}
         assert self.parser.config.agents == {}
@@ -118,7 +118,7 @@ EXPOSE 8080
     def test_empty_agentfile(self):
         """Test parsing empty Agentfile."""
         config = self.parser.parse_content("")
-        assert config.base_image == "fast-agent:latest"
+        assert config.base_image == "yeahdongcn/agentman-base:latest"
         assert len(config.secrets) == 0
         assert len(config.servers) == 0
         assert len(config.agents) == 0
@@ -144,7 +144,7 @@ EXPOSE 8080
     def test_parse_content_with_secret_context_arbitrary_name(self):
         """Test parsing secret context with arbitrary names like 'openai'."""
         content = """
-FROM yeahdongcn/agentman:base
+FROM yeahdongcn/agentman-base:latest
 MODEL generic.qwen3:latest
 
 SECRET openai
@@ -177,6 +177,182 @@ API_KEY claude-key
 
         # Check anthropic secret values
         assert anthropic_secret.values["API_KEY"] == "claude-key"
+
+    def test_parse_run_instruction_single_line(self):
+        """Test parsing single-line RUN instruction."""
+        content = """
+FROM python:3.11-slim
+RUN apt-get update
+"""
+        config = self.parser.parse_content(content)
+
+        assert config.base_image == "python:3.11-slim"
+        assert len(config.dockerfile_instructions) == 2  # FROM and RUN
+
+        # Find the RUN instruction
+        run_instruction = None
+        for instruction in config.dockerfile_instructions:
+            if instruction.instruction == "RUN":
+                run_instruction = instruction
+                break
+
+        assert run_instruction is not None
+        assert run_instruction.instruction == "RUN"
+        assert run_instruction.args == ["apt-get", "update"]
+        assert run_instruction.to_dockerfile_line() == "RUN apt-get update"
+
+    def test_parse_run_instruction_multiline(self):
+        """Test parsing multi-line RUN instruction with backslash continuation."""
+        content = """
+FROM python:3.11-slim
+RUN apt-get update && apt-get install -y \\
+    wget \\
+    curl \\
+    && rm -rf /var/lib/apt/lists/*
+"""
+        config = self.parser.parse_content(content)
+
+        assert config.base_image == "python:3.11-slim"
+        assert len(config.dockerfile_instructions) == 2  # FROM and RUN
+
+        # Find the RUN instruction
+        run_instruction = None
+        for instruction in config.dockerfile_instructions:
+            if instruction.instruction == "RUN":
+                run_instruction = instruction
+                break
+
+        assert run_instruction is not None
+        assert run_instruction.instruction == "RUN"
+
+        # The multi-line command should be combined into a single line
+        expected_command = "apt-get update && apt-get install -y wget curl && rm -rf /var/lib/apt/lists/*"
+        actual_command = " ".join(run_instruction.args)
+        assert actual_command == expected_command
+
+        # Test the Dockerfile line generation
+        expected_dockerfile_line = f"RUN {expected_command}"
+        assert run_instruction.to_dockerfile_line() == expected_dockerfile_line
+
+    def test_parse_run_instruction_complex_multiline(self):
+        """Test parsing complex multi-line RUN instruction like the one in the Agentfile."""
+        content = """
+FROM yeahdongcn/agentman-base:latest
+RUN apt-get update && apt-get install -y \\
+    wget \\
+    && rm -rf /var/lib/apt/lists/*
+"""
+        config = self.parser.parse_content(content)
+
+        assert config.base_image == "yeahdongcn/agentman-base:latest"
+        assert len(config.dockerfile_instructions) == 2  # FROM and RUN
+
+        # Find the RUN instruction
+        run_instruction = None
+        for instruction in config.dockerfile_instructions:
+            if instruction.instruction == "RUN":
+                run_instruction = instruction
+                break
+
+        assert run_instruction is not None
+        assert run_instruction.instruction == "RUN"
+
+        # The multi-line command should be combined correctly
+        expected_command = "apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*"
+        actual_command = " ".join(run_instruction.args)
+        assert actual_command == expected_command
+
+    def test_parse_multiple_dockerfile_instructions(self):
+        """Test parsing multiple Dockerfile instructions with RUN."""
+        content = """
+FROM python:3.11-slim
+WORKDIR /app
+RUN apt-get update
+COPY . .
+RUN pip install -r requirements.txt
+EXPOSE 8080
+CMD ["python", "app.py"]
+"""
+        config = self.parser.parse_content(content)
+
+        assert config.base_image == "python:3.11-slim"
+        assert config.expose_ports == [8080]
+        assert config.cmd == ["python", "app.py"]
+
+        # Check that all Dockerfile instructions are captured in order
+        expected_instructions = [
+            ("FROM", ["python:3.11-slim"]),
+            ("WORKDIR", ["/app"]),
+            ("RUN", ["apt-get", "update"]),
+            ("COPY", [".", "."]),
+            ("RUN", ["pip", "install", "-r", "requirements.txt"]),
+            ("EXPOSE", ["8080"]),
+            ("CMD", ["[\"python\",", "\"app.py\"]"])
+        ]
+
+        assert len(config.dockerfile_instructions) == len(expected_instructions)
+
+        for i, (expected_instruction, expected_args) in enumerate(expected_instructions):
+            actual = config.dockerfile_instructions[i]
+            assert actual.instruction == expected_instruction
+            if expected_instruction == "CMD":
+                # CMD has special handling in the parser
+                continue
+            else:
+                assert actual.args == expected_args
+
+    def test_parse_content_with_unknown_instruction(self):
+        """Test parsing content with an unknown instruction (should be treated as Dockerfile instruction)."""
+        content = """
+FROM python:3.11-slim
+UNKNOWN INSTRUCTION args
+"""
+        config = self.parser.parse_content(content)
+
+        # Unknown instructions should be treated as Dockerfile instructions
+        assert len(config.dockerfile_instructions) == 2  # FROM and UNKNOWN
+
+        unknown_instruction = None
+        for instruction in config.dockerfile_instructions:
+            if instruction.instruction == "UNKNOWN":
+                unknown_instruction = instruction
+                break
+
+        assert unknown_instruction is not None
+        assert unknown_instruction.instruction == "UNKNOWN"
+        assert unknown_instruction.args == ["INSTRUCTION", "args"]
+
+    def test_parse_content_without_from_instruction(self):
+        """Test parsing content without FROM instruction (should still work)."""
+        content = """
+MODEL anthropic/claude-3-sonnet-20241022
+EXPOSE 8080
+"""
+        config = self.parser.parse_content(content)
+
+        # Should not raise an error - FROM is not strictly required anymore
+        assert config.default_model == "anthropic/claude-3-sonnet-20241022"
+        assert config.expose_ports == [8080]
+        assert len(config.dockerfile_instructions) == 1  # EXPOSE
+
+    def test_parse_content_with_duplicate_secret(self):
+        """Test parsing content with duplicate secret definitions."""
+        content = """
+FROM yeahdongcn/agentman-base:latest
+
+SECRET my_secret
+API_KEY sk-test123
+
+SECRET my_secret
+BASE_URL https://api.openai.com/v1
+"""
+        config = self.parser.parse_content(content)
+
+        assert len(config.secrets) == 1  # Only one secret should be created
+        secret = config.secrets[0]
+        assert secret.name == "my_secret"
+        assert secret.values["API_KEY"] == "sk-test123"
+        assert secret.values["BASE_URL"] == "https://api.openai.com/v1"
 
 
 class TestDataClasses:

--- a/tests/test_dockerfile_generation.py
+++ b/tests/test_dockerfile_generation.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Test script to verify EXPOSE and CMD instructions are properly handled in Dockerfile generation."""
+
+import tempfile
+import os
+from pathlib import Path
+
+from agentman.agentfile_parser import AgentfileParser
+from agentman.agent_builder import AgentBuilder
+
+
+def test_dockerfile_generation_with_expose_and_cmd():
+    """Test that EXPOSE and CMD instructions from Agentfile are included in generated Dockerfile."""
+
+    # Create a test Agentfile content with EXPOSE and CMD instructions
+    agentfile_content = """
+FROM python:3.11-slim
+MODEL anthropic/claude-3-sonnet-20241022
+RUN apt-get update && apt-get install -y wget
+EXPOSE 8080
+EXPOSE 9090
+CMD ["python", "agent.py"]
+"""
+
+    # Parse the Agentfile
+    parser = AgentfileParser()
+    config = parser.parse_content(agentfile_content)
+
+    print("Parsed configuration:")
+    print(f"Base image: {config.base_image}")
+    print(f"Default model: {config.default_model}")
+    print(f"Expose ports: {config.expose_ports}")
+    print(f"CMD: {config.cmd}")
+    print(f"Dockerfile instructions: {len(config.dockerfile_instructions)}")
+
+    for i, instruction in enumerate(config.dockerfile_instructions):
+        print(f"  {i}: {instruction.instruction} {instruction.args}")
+
+    # Create a temporary directory for output
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Build the agent
+        builder = AgentBuilder(config, temp_dir)
+        builder._generate_dockerfile()
+
+        # Read the generated Dockerfile
+        dockerfile_path = Path(temp_dir) / "Dockerfile"
+        with open(dockerfile_path, 'r') as f:
+            dockerfile_content = f.read()
+
+        print("\nGenerated Dockerfile:")
+        print(dockerfile_content)
+
+        # Verify EXPOSE and CMD instructions are present
+        assert "EXPOSE 8080" in dockerfile_content, "EXPOSE 8080 not found in Dockerfile"
+        assert "EXPOSE 9090" in dockerfile_content, "EXPOSE 9090 not found in Dockerfile"
+        assert 'CMD ["python", "agent.py"]' in dockerfile_content, "CMD instruction not found in Dockerfile"
+        assert "RUN apt-get update && apt-get install -y wget" in dockerfile_content, "Custom RUN instruction not found"
+
+        print("\n✅ All checks passed! EXPOSE and CMD instructions are properly included.")
+
+
+if __name__ == "__main__":
+    test_dockerfile_generation_with_expose_and_cmd()


### PR DESCRIPTION
## Summary by Sourcery

Enable broader Dockerfile instruction support in AgentfileParser and AgentBuilder, bump the default base image, refine parsing logic (including ENV disambiguation and multi-line continuations), and enhance test coverage and documentation.

New Features:
- Introduce DockerfileInstruction dataclass and capture arbitrary Dockerfile instructions in AgentfileConfig
- Support parsing of RUN, CMD, EXPOSE, WORKDIR, and other Dockerfile instructions with single-line and backslash-continuation formats
- Extend AgentBuilder to include parsed Dockerfile instructions in generated Dockerfiles

Bug Fixes:
- Merge duplicate SECRET definitions into a single secret context

Enhancements:
- Bump default base image from fast-agent:latest to yeahdongcn/agentman-base:latest across code, tests, and documentation
- Refactor Dockerfile generation to streamline instruction inclusion, default WORKDIR setup, and dependency installation
- Disambiguate ENV directives as Dockerfile or secret sub-instructions based on parsing context
- Update CLI description to clarify Agentman’s purpose

Build:
- Change Makefile default target to install and update IMAGE_NAME environment variable

Documentation:
- Update README examples to reference the new base image tag

Tests:
- Add tests for single-line, multi-line, and complex RUN instructions, multiple Dockerfile instructions parsing, unknown instructions, missing FROM cases, and duplicate secrets handling